### PR TITLE
feat: add script for building upgrade tx

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ On successful execution, the script will output:
 - The transaction signature
 - The multisig account address (important to save for future interactions)
 
-## Notes
+### Notes
 
 - By default, the threshold is set to 1 if not specified
 - All members are given full permissions in the multisig
@@ -90,4 +90,50 @@ On successful execution, the script will output:
 - Ensure you have sufficient SOL in your admin account to pay for transaction fees
 - The threshold represents the minimum number of signatures required to approve a transaction
 
+## Build Upgrade Transaction
+
+You can use the `build-upgrade-tx-base58.ts` script to create a serialized base58-encoded transaction message for upgrading a Solana program. This script is useful to prepare upgrade transactions with necessary parameters for execution.
+
+### Setup
+
+Ensure you have set up your keypairs and have the required parameters ready:
+
+1. Make sure to have your `vault_public_key`, `program_id`, `buffer_account`, and `fee_payer_public_key` available.
+2. Set up any required accounts with sufficient SOL to pay for transaction fees and operations.
+
+### Usage
+
+Run the script using the following command:
+
+```bash
+bun run src/build-upgrade-tx-base58.ts [options]
+```
+
+### Required Parameters
+
+- `--vault_public_key <pubkey>`: The public key of the upgrade authority's vault.
+- `--program_id <pubkey>`: The public key of the program you intend to upgrade.
+- `--buffer_account <pubkey>`: The public key of the account containing the new program code.
+- `--fee_payer_public_key <pubkey>`: The public key of the account paying for transaction fees.
+
+### Optional Parameters
+
+- `--url <rpc-url>`: Custom RPC URL to connect to the Solana network (defaults to `https://api.testnet.sonic.game`).
+
+### Examples
+
+Generate a base58-encoded transaction message for an upgrade:
+
+```bash
+$ bun run src/build-upgrade-tx-base58.ts \
+    --vault_public_key 1U6E64e893D8AgK6JBFjzFFAWupkzBjhUASg6Py8HZv \
+    --program_id DyA8s2ZrxpAcVevwYmEXZfddsKxAELo1ZjQtYpKRKzTz \
+    --buffer_account  8FYJs2ChoEW7hAyzKzppwj9tmcTb6eaGHoCgqSApStRh \
+    --fee_payer_public_key Gi2ommjX7QKTHPsyr96XSPoBDzzNnS4rtjMp4B4eEXas
+
+Base58 Encoded Transaction Message:
+PDbtyEi9CGUCvTKfdZqh7Vm3uQJo68cPFH8biFc5MgpdZpRRv87UuqrenLZQTiottqdZvVoQRUXzZ9h6pfiPSsu6xT1ZdmiBgNnfBFbEJd2Fw5HZMaLoBMZyx6jWh9rY5mbNmeZBGkwHsFyisEaBJCCZ3aLzvoGZPau5cJZsxRdUtq74DrMzn5J4EZHHDyGVmzUeLqiGZdqtLMNExDBRUrFe6HUNiPX43pmBBmadU7RvLBGidts1jaVWEGR92vGDRKmRNcmyevxgPk6tkZtLW5TC4m1pqsNBwfMaMH9W4W3tdVzQVPmgyCuEScE16Qys7EMkcNMrxkFv4VTBDLqsypecPVof8RdhLMGfDRZmLBLRSXmp62E7UF9R2CyPssmJVEMStnP42i7VMmRwXN56djGaocomRRj685xJ1razfmWbssmNKVCMLfo5q8ee1Uw9xxAninUy72K5i7
+```
+
+## Notes
 This project was created using `bun init` in bun v1.1.18. [Bun](https://bun.sh) is a fast all-in-one JavaScript runtime.

--- a/src/build-upgrade-tx-base58.ts
+++ b/src/build-upgrade-tx-base58.ts
@@ -6,12 +6,8 @@ import {
 } from '@solana/web3.js';
 import bs58 from 'bs58';
 import { parseArgs } from "util";
-import {
-  DEFAULT_RPC_URL,
-} from "./utils/constants";
-import {
-  validateRpcUrl,
-} from "./utils/validators";
+import { DEFAULT_RPC_URL } from "./utils/constants";
+import { validateRpcUrl } from "./utils/validators";
 
 const { values } = parseArgs({
   args: Bun.argv,
@@ -50,14 +46,10 @@ if (!values.vault_public_key) {
     process.exit(1);
 }
 
-// const VAULT_PUBLIC_KEY = new PublicKey("1U6E64e893D8AgK6JBFjzFFAWupkzBjhUASg6Py8HZv")
-// const PROGRAM_ID = new PublicKey("DyA8s2ZrxpAcVevwYmEXZfddsKxAELo1ZjQtYpKRKzTz");
-// const BUFFER_ACCOUNT = new PublicKey("8FYJs2ChoEW7hAyzKzppwj9tmcTb6eaGHoCgqSApStRh");
-
 const VAULT_PUBLIC_KEY = new PublicKey(values.vault_public_key)
 const PROGRAM_ID = new PublicKey(values.program_id);
 const BUFFER_ACCOUNT = new PublicKey(values.buffer_account);
-const FEE_PAYER_PUBLIC_KEY = new PublicKey(values.fee_payer_public_key); // Gi2ommjX7QKTHPsyr96XSPoBDzzNnS4rtjMp4B4eEXas
+const FEE_PAYER_PUBLIC_KEY = new PublicKey(values.fee_payer_public_key);
 
 const rpcUrl = values.url
   ? validateRpcUrl(values.url)

--- a/src/build-upgrade-tx-base58.ts
+++ b/src/build-upgrade-tx-base58.ts
@@ -1,0 +1,154 @@
+import {
+    Connection, PublicKey,
+    Transaction, TransactionInstruction,
+    SYSVAR_CLOCK_PUBKEY,
+    SYSVAR_RENT_PUBKEY,
+} from '@solana/web3.js';
+import bs58 from 'bs58';
+import { parseArgs } from "util";
+import {
+  DEFAULT_RPC_URL,
+} from "./utils/constants";
+import {
+  validateRpcUrl,
+} from "./utils/validators";
+
+const { values } = parseArgs({
+  args: Bun.argv,
+  options: {
+    url: {
+      type: "string",
+    },
+    vault_public_key: {
+      type: "string",
+    },
+    fee_payer_public_key: {
+      type: "string",
+    },
+    program_id: {
+      type: "string",
+    },
+    buffer_account: {
+      type: "string",
+    },
+  },
+  strict: true,
+  allowPositionals: true,
+});
+
+if (!values.vault_public_key) {
+    console.error("--vault_public_key is required");
+    process.exit(1);
+} else if (!values.program_id) {
+    console.error("--program_id is required");
+    process.exit(1);
+} else if (!values.buffer_account) {
+    console.error("--buffer_account is required");
+    process.exit(1);
+} else if (!values.fee_payer_public_key) {
+    console.error("--fee_payer_public_key is required");
+    process.exit(1);
+}
+
+// const VAULT_PUBLIC_KEY = new PublicKey("1U6E64e893D8AgK6JBFjzFFAWupkzBjhUASg6Py8HZv")
+// const PROGRAM_ID = new PublicKey("DyA8s2ZrxpAcVevwYmEXZfddsKxAELo1ZjQtYpKRKzTz");
+// const BUFFER_ACCOUNT = new PublicKey("8FYJs2ChoEW7hAyzKzppwj9tmcTb6eaGHoCgqSApStRh");
+
+const VAULT_PUBLIC_KEY = new PublicKey(values.vault_public_key)
+const PROGRAM_ID = new PublicKey(values.program_id);
+const BUFFER_ACCOUNT = new PublicKey(values.buffer_account);
+const FEE_PAYER_PUBLIC_KEY = new PublicKey(values.fee_payer_public_key); // Gi2ommjX7QKTHPsyr96XSPoBDzzNnS4rtjMp4B4eEXas
+
+const rpcUrl = values.url
+  ? validateRpcUrl(values.url)
+    ? values.url
+    : (() => {
+        throw new Error(`Invalid RPC URL: ${values.url}`);
+      })()
+  : DEFAULT_RPC_URL;
+
+const connection = new Connection(rpcUrl, "recent");
+
+const BPF_LOADER_UPGRADEABLE = new PublicKey("BPFLoaderUpgradeab1e11111111111111111111111");
+
+async function createUpgradeInstruction(
+    programId: PublicKey,
+    bufferAddress: PublicKey,
+    upgradeAuthority: PublicKey,
+    spillAddress: PublicKey
+  ): Promise<TransactionInstruction> {
+    const [programDataAddress] = await PublicKey.findProgramAddressSync(
+      [programId.toBuffer()],
+      BPF_LOADER_UPGRADEABLE
+    )
+  
+    const keys = [
+      {
+        pubkey: programDataAddress,
+        isWritable: true,
+        isSigner: false,
+      },
+      {
+        pubkey: programId,
+        isWritable: true,
+        isSigner: false,
+      },
+      {
+        pubkey: bufferAddress,
+        isWritable: true,
+        isSigner: false,
+      },
+      {
+        pubkey: spillAddress,
+        isWritable: true,
+        isSigner: false,
+      },
+      {
+        pubkey: SYSVAR_RENT_PUBKEY,
+        isWritable: false,
+        isSigner: false,
+      },
+      {
+        pubkey: SYSVAR_CLOCK_PUBKEY,
+        isWritable: false,
+        isSigner: false,
+      },
+      {
+        pubkey: upgradeAuthority,
+        isWritable: false,
+        isSigner: true,
+      },
+    ]
+  
+    return new TransactionInstruction({
+      keys,
+      programId: BPF_LOADER_UPGRADEABLE,
+      data: Buffer.from([3, 0, 0, 0]), // Upgrade instruction bincode
+    })
+}
+
+async function createUpgradeTransaction() {
+    const [spillAddress, ] = await PublicKey.findProgramAddressSync(
+        [BUFFER_ACCOUNT.toBuffer(), Buffer.from("spill")],
+        BPF_LOADER_UPGRADEABLE
+    );
+
+    const upgradeInstruction = await createUpgradeInstruction(
+        PROGRAM_ID,
+        BUFFER_ACCOUNT,
+        VAULT_PUBLIC_KEY,
+        spillAddress,
+    )
+
+    const transaction = new Transaction().add(upgradeInstruction);
+    transaction.recentBlockhash = (await connection.getLatestBlockhash()).blockhash;
+    transaction.feePayer = FEE_PAYER_PUBLIC_KEY
+
+    const message = transaction.serializeMessage();
+    const base58Message = bs58.encode(message);
+
+    console.log("Base58 Encoded Transaction Message:");
+    console.log(base58Message);
+}
+
+createUpgradeTransaction();


### PR DESCRIPTION
Examples

Generate a base58-encoded transaction message for an upgrade:

```bash
$ bun run src/build-upgrade-tx-base58.ts \
    --vault_public_key 1U6E64e893D8AgK6JBFjzFFAWupkzBjhUASg6Py8HZv \
    --program_id DyA8s2ZrxpAcVevwYmEXZfddsKxAELo1ZjQtYpKRKzTz \
    --buffer_account  8FYJs2ChoEW7hAyzKzppwj9tmcTb6eaGHoCgqSApStRh \
    --fee_payer_public_key Gi2ommjX7QKTHPsyr96XSPoBDzzNnS4rtjMp4B4eEXas

Base58 Encoded Transaction Message:
PDbtyEi9CGUCvTKfdZqh7Vm3uQJo68cPFH8biFc5MgpdZpRRv87UuqrenLZQTiottqdZvVoQRUXzZ9h6pfiPSsu6xT1ZdmiBgNnfBFbEJd2Fw5HZMaLoBMZyx6jWh9rY5mbNmeZBGkwHsFyisEaBJCCZ3aLzvoGZPau5cJZsxRdUtq74DrMzn5J4EZHHDyGVmzUeLqiGZdqtLMNExDBRUrFe6HUNiPX43pmBBmadU7RvLBGidts1jaVWEGR92vGDRKmRNcmyevxgPk6tkZtLW5TC4m1pqsNBwfMaMH9W4W3tdVzQVPmgyCuEScE16Qys7EMkcNMrxkFv4VTBDLqsypecPVof8RdhLMGfDRZmLBLRSXmp62E7UF9R2CyPssmJVEMStnP42i7VMmRwXN56djGaocomRRj685xJ1razfmWbssmNKVCMLfo5q8ee1Uw9xxAninUy72K5i7
```